### PR TITLE
correct typo in use_maintenance_policy

### DIFF
--- a/src/components/modals/cluster/ClusterUpgradeDataProvider.js
+++ b/src/components/modals/cluster/ClusterUpgradeDataProvider.js
@@ -126,7 +126,7 @@ async function upgradeCluster ({
     host_names: ansiblePayload.hostNames,
     check_upgrade: ansiblePayload.checkForUpgradesOnHosts,
     reboot_after_upgrade: ansiblePayload.rebootAfterUpgrade,
-    use_maintenace_policy: ansiblePayload.useMaintenanceClusterPolicy
+    use_maintenance_policy: ansiblePayload.useMaintenanceClusterPolicy
   })
   const playbookName = config.clusterUpgradePlaybook
 


### PR DESCRIPTION
Currently, the option to disallow changing a cluster to the maintenance scheduler does not work. This change will correct a typo and set the correct use_maintenance_policy option that ansile expects.