### PR TITLE
cluster upgrade: use correlation id for ansible playbooks

### DIFF
--- a/src/modals/cluster-upgrade/ClusterUpgradeDataProvider.js
+++ b/src/modals/cluster-upgrade/ClusterUpgradeDataProvider.js
@@ -9,7 +9,6 @@ import * as C from '_/constants'
 import { engineGet, ansiblePlaybookPost } from '_/utils/fetch'
 import { randomHexString } from '_/utils/random'
 import { msg } from '_/intl-messages'
-import { applySearch } from '_/utils/webadmin-search'
 
 //
 // for FAKE_DATA=true
@@ -151,10 +150,6 @@ async function upgradeCluster ({
       C.webadminToastTypes.info,
       msg.clusterUpgradeOperationStarted({ clusterName })
     )
-    applySearch(C.webadminPlaces.event, C.searchPrefixes.event, [{
-      name: 'correlation_id',
-      values: [engineCorrelationId],
-    }])
   } catch (error) {
     console.error(
       'upgradeCluster: the ansible service failed\n\nplaybook: %s\nansibleVariables:\n%s',

--- a/src/utils/random.js
+++ b/src/utils/random.js
@@ -1,3 +1,24 @@
-// TODO(vs) consider moving this to patternfly-react helpers along
 // with any existing occurrences, like in UtilizationBar component.
-export const randomId = () => `generated-id-${Date.now() * Math.random()}`
+export const randomId = () => `generated-id-${randomHexString()}`
+
+/**
+ * Generate a string of hex characters of the specified length.
+ *
+ * @param {*} length String length
+ */
+export const randomHexString = (length = 10) => {
+  if (length <= 0) {
+    return ''
+  }
+
+  let str = ''
+  for (let i = 0; i < length; i++) {
+    str += randomHexDigit()
+  }
+  return str
+}
+
+export function randomHexDigit () {
+  const digit = Math.floor(Math.random() * 16)
+  return digit.toString(16)
+}

--- a/src/utils/random.js
+++ b/src/utils/random.js
@@ -1,4 +1,3 @@
-// with any existing occurrences, like in UtilizationBar component.
 export const randomId = () => `generated-id-${randomHexString()}`
 
 /**

--- a/src/utils/random.test.js
+++ b/src/utils/random.test.js
@@ -1,0 +1,44 @@
+import { randomHexString, randomHexDigit, randomId } from './random'
+
+describe('random digit tests', () => {
+  it('get a digit between 0 and F', () => {
+    for (let i = 0; i < 10; i++) {
+      expect(randomHexDigit()).toEqual(expect.stringMatching(/^[0123456789abcedf]$/))
+    }
+  })
+})
+
+describe('random hex string tests', () => {
+  it('length <= 0 is empty string', () => {
+    expect(randomHexString(-1)).toBe('')
+    expect(randomHexString(0)).toBe('')
+  })
+
+  it('length > 0 is a random string of that length', () => {
+    const randomString = expect.stringMatching(/^[0123456789abcedf]+$/)
+
+    for (let i = 1; i <= 20; i++) {
+      const toTest = randomHexString(i)
+      expect(toTest).toHaveLength(i)
+      expect(toTest).toEqual(randomString)
+    }
+  })
+
+  it('no length specified is 10 random hex characters', () => {
+    const tenRandom = expect.stringMatching(/^[0123456789abcedf]{10}$/)
+
+    for (let i = 0; i < 10; i++) {
+      expect(randomHexString()).toEqual(tenRandom)
+    }
+  })
+})
+
+describe('random id tests', () => {
+  const randomIdRegex = expect.stringMatching(/^generated-id-[0123456789abcedf]{10}$/)
+
+  it('is the expected format', () => {
+    for (let i = 0; i < 10; i++) {
+      expect(randomId()).toEqual(randomIdRegex)
+    }
+  })
+})

--- a/src/utils/webadmin-search.js
+++ b/src/utils/webadmin-search.js
@@ -20,6 +20,13 @@ export function buildSearch (prefix, fields = []) {
   return str
 }
 
+/**
+ * Apply a search query to the given webadmin place.
+ *
+ * @param {string} place Top level place to navigate the user
+ * @param {string} prefix Primary search entity
+ * @param {[{ name: string, values: [string], operator: string }]} fields Search fields and values
+ */
 export function applySearch (place, prefix, fields = []) {
   getPluginApi().revealPlace(place)
   getPluginApi().setSearchString(buildSearch(prefix, fields))


### PR DESCRIPTION
Create a random 10 hex-digit string to use as a correlation id
when starting the cluster upgrade playbook.  The correlation id
will be used by all of the progress events and by the other tasks
run by the ansible role.

Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=2040474
Replaces: https://gerrit.ovirt.org/c/ovirt-engine-ui-extensions/+/118294