### PR TITLE
Add OST trigger

### DIFF
--- a/.github/workflows/comment-to-trigger-ost.yaml
+++ b/.github/workflows/comment-to-trigger-ost.yaml
@@ -1,0 +1,18 @@
+name: comment '/ost' to trigger OST on a PR
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  trigger-ost:
+    if: |
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/ost') &&
+      (
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR'
+      )
+    uses: oVirt/ovirt-system-tests/.github/workflows/ost.yaml@master
+    with:
+      pr_url: ${{ github.event.issue.pull_request.url }}


### PR DESCRIPTION
Add a workflow triggered by adding a comment "/ost" to a PR that will start an OST run against the PR.

The workflow can only be trigger by users whose association to the repository is one of:
  - COLLABORATOR (i.e. Maintainer) of the repository
  - MEMBER of the organization that owns the repository (oVirt)