### PR TITLE
Introduce Storage Connections management dialog

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -71,6 +71,7 @@ export const entityTypes = {
   vm: 'VirtualMachine',
   hostDevices: 'HostDevice',
   vmDevices: 'VirtualMachineDevice',
+  storage: 'Storage',
 }
 
 export const heatMapThresholds = {

--- a/src/integrations/buttons.js
+++ b/src/integrations/buttons.js
@@ -8,6 +8,7 @@ import { showVmMigrateModal } from './showVmMigrate'
 import { showClusterUpgradeWizard } from './showClusterUpgrade'
 import { showVmExportModal } from './showVmExport'
 import { showHostCopyNetworksModal } from './showHostCopyNetworks'
+import { showStorageConnectionsModal } from './showStorageConnectionsModal'
 
 function isVmUp (vm) {
   return vmUpStates.includes(vm.status)
@@ -160,6 +161,27 @@ function addHostCpuPinningButton () {
   })
 }
 
+/**
+ * "Connections" button in the Storage Domains list. Enabled when exactly 1 iSCSI domain is selected
+ */
+function addManageStorageConnectionsButton () {
+  getPluginApi().addMenuPlaceActionButton(entityTypes.storage, msg.storageConnectionsManageButton(), {
+    onClick: function ([selectedDomain]) {
+      showStorageConnectionsModal(selectedDomain)
+    },
+
+    isEnabled: function (selectedDomains) {
+      return (
+        selectedDomains.length === 1 &&
+        selectedDomains[0]?.type?.toLowerCase() === 'iscsi'
+      )
+    },
+
+    index: 4,
+    id: 'StorageConnectionsButton',
+  })
+}
+
 export function addButtons () {
   addVmManageGpuButton()
   addVmCpuPinningButton()
@@ -169,4 +191,5 @@ export function addButtons () {
   addClusterUpgradeButton()
   addHostCopyNetworksButton()
   addHostCpuPinningButton()
+  addManageStorageConnectionsButton()
 }

--- a/src/integrations/showStorageConnectionsModal.js
+++ b/src/integrations/showStorageConnectionsModal.js
@@ -1,0 +1,17 @@
+import React from 'react'
+import { renderComponent } from '_/utils/react-modals'
+
+import StorageConnectionsModal from '_/modals/storage-connections/StorageConnectionsModal'
+import StorageConnectionsDataProvider from '_/modals/storage-connections/StorageConnectionsDataProvider'
+
+export function showStorageConnectionsModal (storageDomain) {
+  renderComponent(
+    ({ unmountComponent }) => (
+      <StorageConnectionsDataProvider storageDomain={storageDomain}>
+        <StorageConnectionsModal
+          onClose={unmountComponent}
+        />
+      </StorageConnectionsDataProvider>
+    )
+  )
+}

--- a/src/intl/messages.js
+++ b/src/intl/messages.js
@@ -1181,6 +1181,140 @@ const messageDescriptors = {
     defaultMessage: 'Core {id, number, ::.}',
     description: 'core',
   },
+
+  // Storage Connections modal dialog related strings
+
+  storageConnectionsManageButton: {
+    id: 'storage.domains.connections.buttonLabel',
+    defaultMessage: 'Connections',
+    description: 'label for Storage Connections management dialog button',
+  },
+
+  storageConnectionsDataError: {
+    id: 'storage.domains.connections.dataError',
+    defaultMessage: 'Could not fetch data needed for showing Storage Connections',
+    description: 'notification shown when Storage Connections dialog failed to load its data',
+  },
+
+  storageConnectionsTitle: {
+    id: 'storage.domains.connections.title',
+    defaultMessage: 'Manage Storage Connections',
+    description: 'title of Storage Connections dialog',
+  },
+
+  storageConnectionsTitleWithName: {
+    id: 'storage.domains.connections.title.withName',
+    defaultMessage: 'Manage Storage Connections - {sdName}',
+    description: 'title of Storage Connections dialog with name',
+  },
+
+  storageConnectionsTableColAddress: {
+    id: 'storage.domains.connections.table.column.address',
+    defaultMessage: 'Address',
+    description: 'address column of Storage Connections Table',
+  },
+
+  storageConnectionsTableColPort: {
+    id: 'storage.domains.connections.table.column.port',
+    defaultMessage: 'Port',
+    description: 'port column of Storage Connections Table',
+  },
+
+  storageConnectionsTableColTarget: {
+    id: 'storage.domains.connections.table.column.target',
+    defaultMessage: 'Target',
+    description: 'target column of Storage Connections Table',
+  },
+
+  storageConnectionsTableColPath: {
+    id: 'storage.domains.connections.table.column.path',
+    defaultMessage: 'Path',
+    description: 'path column of Storage Connections Table',
+  },
+
+  storageConnectionsTableColAttached: {
+    id: 'storage.domains.connections.table.column.attached',
+    defaultMessage: 'Attached',
+    description: 'attached column of Storage Connections Table',
+  },
+
+  storageConnectionsTableAttachedStr: {
+    id: 'storage.domains.connections.table.connection.attached',
+    defaultMessage: 'ATTACHED',
+    description: 'attached string in Storage Connections Table',
+  },
+
+  storageConnectionsRemoveConnectionButton: {
+    id: 'storage.domains.connections.connection.remove.button',
+    defaultMessage: 'Remove',
+    description: 'remove Connection button',
+  },
+
+  storageConnectionsAddConnectionButton: {
+    id: 'storage.domains.connections.connection.add.button',
+    defaultMessage: 'Add',
+    description: 'add Connection button',
+  },
+
+  storageConnectionsAttachConnectionButton: {
+    id: 'storage.domains.connections.connection.attach.button',
+    defaultMessage: 'Attach',
+    description: 'attach Connection button',
+  },
+
+  storageConnectionsDetachConnectionButton: {
+    id: 'storage.domains.connections.connection.detach.button',
+    defaultMessage: 'Detach',
+    description: 'detach Connection button',
+  },
+
+  storageConnectionsDomainNotInMaintenanceWarning: {
+    id: 'storage.domains.connections.domain.maintenance.warning',
+    defaultMessage: 'Storage Domain is not in Maintenance mode',
+    description: 'storage Domain is not in Maintenance mode Warning',
+  },
+
+  storageConnectionsDomainNotInMaintenanceWarningDetail: {
+    id: 'storage.domains.connections.domain.maintenance.warning.detail',
+    defaultMessage: 'Connections cannot be attached or detached, cannot edit attached connections',
+    description: 'storage Domain is not in Maintenance mode Warning Detail',
+  },
+
+  storageConnectionsShowAllConnectionsSwitchOn: {
+    id: 'storage.domains.connections.showAll.switch.on',
+    defaultMessage: 'On',
+    description: 'show all connections switch on',
+  },
+
+  storageConnectionsShowAllConnectionsSwitchOff: {
+    id: 'storage.domains.connections.showAll.switch.off',
+    defaultMessage: 'Off',
+    description: 'show all connections switch off',
+  },
+
+  storageConnectionsShowAllConnectionsLabel: {
+    id: 'storage.domains.connections.showAll.label',
+    defaultMessage: 'Show all connections',
+    description: 'show all connections label',
+  },
+
+  storageConnectionsOperationFailedTitle: {
+    id: 'storage.domains.connections.operation.failed.title',
+    defaultMessage: 'Operation Failed',
+    description: 'storage Connection operation failed title',
+  },
+
+  storageConnectionsFieldRequiredError: {
+    id: 'storage.domains.connections.field.required.error',
+    defaultMessage: 'This field is required',
+    description: 'field required error message',
+  },
+
+  storageConnectionsFieldPortError: {
+    id: 'storage.domains.connections.field.port.error',
+    defaultMessage: 'Invalid port value',
+    description: 'invalid port field value error',
+  },
 }
 
 module.exports = exports = messageDescriptors

--- a/src/modals/storage-connections/StorageConnectionsDataProvider.js
+++ b/src/modals/storage-connections/StorageConnectionsDataProvider.js
@@ -1,0 +1,118 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import getPluginApi from '_/plugin-api'
+import { engineGet, enginePost, enginePut, engineDelete } from '_/utils/fetch'
+import DataProvider from '_/components/helper/DataProvider'
+import { webadminToastTypes } from '_/constants'
+import { msg } from '_/intl-messages'
+
+const createConnection = async (connection) => {
+  return await enginePost(
+    'api/storageconnections',
+    JSON.stringify(connection)
+  )
+}
+
+const editConnection = async (connection, connectionId) => {
+  return await enginePut(
+    `api/storageconnections/${connectionId}`,
+    JSON.stringify(connection)
+  )
+}
+
+const deleteConnection = async (connectionId) => {
+  return await engineDelete(`api/storageconnections/${connectionId}`)
+}
+
+const attachConnection = async (connectionId, domainId) => {
+  return await enginePost(
+    `api/storagedomains/${domainId}/storageconnections`,
+    JSON.stringify({ id: connectionId })
+  )
+}
+
+const detachConnection = async (connectionId, domainId) => {
+  return await engineDelete(`api/storagedomains/${domainId}/storageconnections/${connectionId}`)
+}
+
+const fetchData = async (stgDomain) => {
+  if (!stgDomain?.id || !stgDomain?.dataCenterId) {
+    throw new Error('StorageConnectionsDataProvider: invalid Storage Domain')
+  }
+  const [allConnectionsJson, storageDomain, domainConnectionsJson] = await Promise.all([
+    engineGet('api/storageconnections'),
+    engineGet(`api/datacenters/${stgDomain.dataCenterId}/storagedomains/${stgDomain.id}`),
+    engineGet(`api/storagedomains/${stgDomain.id}/storageconnections`),
+  ])
+
+  if (!storageDomain) {
+    throw new Error('StorageConnectionsDataProvider: failed to fetch storage domain')
+  }
+
+  const allConnections = allConnectionsJson?.storage_connection
+  const domainConnections = domainConnectionsJson?.storage_connection
+
+  if (!allConnections || allConnections.error) {
+    throw new Error('StorageConnectionsDataProvider: failed to fetch storage connections')
+  }
+
+  if (!domainConnections || domainConnections.error) {
+    throw new Error('StorageConnectionsDataProvider: failed to fetch storage connections' +
+      'for storage domain ' + stgDomain.id)
+  }
+
+  const domainConnectionsIds = new Set(domainConnections.map(connection => connection.id))
+  const allConnectionsByTypeSorted = allConnections
+    .filter(connection => connection.type === storageDomain.storage?.type)
+    .map((conn) => {
+      return { ...conn, isAttachedToDomain: domainConnectionsIds.has(conn.id) }
+    })
+    .sort((conn1, conn2) => {
+      return (conn1.isAttachedToDomain === conn2.isAttachedToDomain) ? 0 : conn1.isAttachedToDomain ? -1 : 1
+    })
+
+  return {
+    storageDomain: storageDomain,
+    connections: allConnectionsByTypeSorted,
+  }
+}
+
+const StorageConnectionsDataProvider = ({ children, storageDomain }) => (
+  <DataProvider fetchData={() => fetchData(storageDomain)}>
+    {({ data, fetchError, lastUpdated, fetchAndUpdateData }) => {
+      // expecting single child component
+      const child = React.Children.only(children)
+
+      // handle data loading and error scenarios
+      if (fetchError) {
+        getPluginApi().showToast(webadminToastTypes.danger, msg.storageConnectionsDataError())
+        return null
+      }
+
+      if (!data) {
+        return React.cloneElement(child, { isLoading: true })
+      }
+
+      const { storageDomain, connections } = data
+
+      return React.cloneElement(child, {
+        storageDomain,
+        connections,
+        lastUpdated,
+        doConnectionCreate: createConnection,
+        doConnectionEdit: editConnection,
+        doConnectionDelete: deleteConnection,
+        doConnectionAttach: attachConnection,
+        doConnectionDetach: detachConnection,
+        doRefreshConnections: () => { fetchAndUpdateData() },
+      })
+    }}
+  </DataProvider>
+)
+
+StorageConnectionsDataProvider.propTypes = {
+  children: PropTypes.element.isRequired,
+  storageDomain: PropTypes.object.isRequired,
+}
+
+export default StorageConnectionsDataProvider

--- a/src/modals/storage-connections/StorageConnectionsModal.js
+++ b/src/modals/storage-connections/StorageConnectionsModal.js
@@ -1,0 +1,148 @@
+import React, { useState, useEffect } from 'react'
+import PropTypes from 'prop-types'
+import PluginApiModal from '_/components/modals/PluginApiModal'
+import getPluginApi from '_/plugin-api'
+import { msg } from '_/intl-messages'
+import { Spinner } from 'patternfly-react'
+import { Button } from '@patternfly/react-core'
+import StorageConnectionsModalBody from './StorageConnectionsModalBody'
+import { createErrorMessage } from '_/utils/error-message'
+import './connections.css'
+
+const StorageConnectionsModal = ({
+  isLoading = false,
+  storageDomain,
+  connections,
+  onClose,
+  doConnectionCreate = () => { },
+  doConnectionEdit = () => { },
+  doConnectionDelete = () => { },
+  doConnectionAttach = () => { },
+  doConnectionDetach = () => { },
+  doRefreshConnections = () => { },
+}) => {
+  const [isOpen, setOpen] = useState(true)
+  const [error, setError] = useState(null)
+  const [isShowAll, setShowAll] = useState(false)
+  const [shownConnections, setShownConnections] = useState(null)
+
+  useEffect(() => {
+    setShownConnections(isShowAll || !connections ? connections : connections.filter(conn => conn.isAttachedToDomain))
+  }, [isShowAll, connections])
+
+  if (!connections) {
+    return null
+  }
+
+  const close = () => {
+    setOpen(false)
+    onClose()
+  }
+
+  const modalActions = [
+    <Button
+      key='storage-connections-modal-cancel-button'
+      variant='primary'
+      onClick={close}
+    >
+      {msg.closeButton()}
+    </Button>,
+  ]
+
+  const onConnectionCreate = async (connection) => {
+    try {
+      await doConnectionCreate(connection)
+      doRefreshConnections()
+      setShowAll(true)
+    } catch (e) {
+      getPluginApi().logger().severe('Error while creating connection. ' + createErrorMessage(e))
+      setError(e.detail)
+    }
+  }
+
+  const onConnectionEdit = async (connection, connectionId) => {
+    try {
+      await doConnectionEdit(connection, connectionId)
+      doRefreshConnections()
+    } catch (e) {
+      getPluginApi().logger().severe('Error while editing connection. ' + createErrorMessage(e))
+      setError(e.detail)
+    }
+  }
+
+  const onConnectionDelete = async (connectionId) => {
+    try {
+      await doConnectionDelete(connectionId)
+      doRefreshConnections()
+    } catch (e) {
+      getPluginApi().logger().severe('Error while deleting connection. ' + createErrorMessage(e))
+      setError(e.detail)
+    }
+  }
+
+  const onConnectionAttach = async (connectionId, domainId) => {
+    try {
+      await doConnectionAttach(connectionId, domainId)
+      doRefreshConnections()
+    } catch (e) {
+      getPluginApi().logger().severe('Error while attaching connection. ' + createErrorMessage(e))
+      setError(e.detail)
+    }
+  }
+
+  const onConnectionDetach = async (connectionId, domainId) => {
+    try {
+      await doConnectionDetach(connectionId, domainId)
+      doRefreshConnections()
+    } catch (e) {
+      getPluginApi().logger().severe('Error while detaching connection. ' + createErrorMessage(e))
+      setError(e.detail)
+    }
+  }
+
+  return (
+    <PluginApiModal
+      className='storage-connections-modal'
+      variant='large'
+      title={
+        storageDomain
+          ? msg.storageConnectionsTitleWithName({ sdName: storageDomain.name })
+          : msg.storageConnectionsTitle()
+      }
+      isOpen={isOpen}
+      onClose={close}
+      actions={modalActions}
+    >
+      <Spinner loading={isLoading}>
+        <StorageConnectionsModalBody
+          storageDomain={storageDomain}
+          connections={shownConnections}
+          isShowAll={isShowAll}
+          setShowAll={setShowAll}
+          error={error}
+          setError={setError}
+          onCreate={onConnectionCreate}
+          onEdit={onConnectionEdit}
+          onDelete={onConnectionDelete}
+          onAttach={onConnectionAttach}
+          onDetach={onConnectionDetach}
+        />
+      </Spinner>
+    </PluginApiModal>
+  )
+}
+
+StorageConnectionsModal.propTypes = {
+  isLoading: PropTypes.bool,
+  storageDomain: PropTypes.object,
+  connections: PropTypes.array,
+  onClose: PropTypes.func.isRequired,
+  doConnectionCreate: PropTypes.func,
+  doConnectionEdit: PropTypes.func,
+  doConnectionDelete: PropTypes.func,
+  doConnectionAttach: PropTypes.func,
+  doConnectionDetach: PropTypes.func,
+  doRefreshConnections: PropTypes.func,
+}
+
+export default StorageConnectionsModal

--- a/src/modals/storage-connections/StorageConnectionsModalBody.js
+++ b/src/modals/storage-connections/StorageConnectionsModalBody.js
@@ -1,0 +1,116 @@
+import React, { useState } from 'react'
+import PropTypes from 'prop-types'
+import {
+  Button,
+  Stack,
+  StackItem,
+  Flex,
+  FlexItem,
+  Alert,
+  Switch,
+  AlertActionCloseButton,
+} from '@patternfly/react-core'
+import StorageConnectionsTable from './StorageConnectionsTable'
+import { msg } from '_/intl-messages'
+import './connections.css'
+
+const StorageConnectionsModalBody = ({
+  storageDomain,
+  connections,
+  isShowAll,
+  setShowAll,
+  error,
+  setError,
+  warning,
+  onCreate,
+  onEdit,
+  onDelete,
+  onAttach,
+  onDetach,
+}) => {
+  const [isNewConnectionOpened, setNewConnectionOpened] = useState(false)
+
+  const handleSwitchShowAll = (checked) => {
+    setShowAll(checked)
+  }
+
+  const handleAddNewConnectionButtonClick = () => {
+    setNewConnectionOpened(true)
+  }
+
+  return (
+    <Stack hasGutter>
+      {error && (
+        <StackItem>
+          <Alert
+            variant='danger'
+            isInline
+            title={msg.storageConnectionsOperationFailedTitle()}
+            actionClose={<AlertActionCloseButton onClose={() => setError(null)} />}
+          >
+            {error}
+          </Alert>
+        </StackItem>
+      )}
+      {(storageDomain?.status !== 'maintenance') && (
+        <StackItem>
+          <Alert variant='warning' isInline title={msg.storageConnectionsDomainNotInMaintenanceWarning()}>
+            {msg.storageConnectionsDomainNotInMaintenanceWarningDetail()}
+          </Alert>
+        </StackItem>
+      )}
+      <StackItem>
+        <Flex>
+          <FlexItem>
+            <Switch
+              id='connections-show-all-switch'
+              label={msg.storageConnectionsShowAllConnectionsLabel()}
+              isChecked={isShowAll}
+              onChange={value => handleSwitchShowAll(value)}
+            />
+          </FlexItem>
+          <FlexItem align={{ default: 'alignRight' }}>
+            <Button
+              variant='secondary'
+              onClick={handleAddNewConnectionButtonClick}
+              isDisabled={isNewConnectionOpened}
+            >
+              {msg.storageConnectionsAddConnectionButton()}
+            </Button>
+          </FlexItem>
+        </Flex>
+      </StackItem>
+      <StackItem>
+        <StorageConnectionsTable
+          type={storageDomain.storage.type}
+          connections={connections}
+          isNewConnectionOpened={isNewConnectionOpened}
+          setNewConnectionOpened={setNewConnectionOpened}
+          storageDomain={storageDomain}
+          onCreate={onCreate}
+          onEdit={onEdit}
+          onDelete={onDelete}
+          onAttach={onAttach}
+          onDetach={onDetach}
+        />
+      </StackItem>
+    </Stack>
+  )
+}
+
+StorageConnectionsModalBody.propTypes = {
+  storageDomain: PropTypes.object,
+  connections: PropTypes.array,
+  isShowAll: PropTypes.bool,
+  setShowAll: PropTypes.func,
+  error: PropTypes.string,
+  setError: PropTypes.func,
+  warning: PropTypes.bool,
+  onCreate: PropTypes.func,
+  onEdit: PropTypes.func,
+  onDelete: PropTypes.func,
+  onAttach: PropTypes.func,
+  onDetach: PropTypes.func,
+}
+
+export default StorageConnectionsModalBody

--- a/src/modals/storage-connections/StorageConnectionsTable.js
+++ b/src/modals/storage-connections/StorageConnectionsTable.js
@@ -1,0 +1,335 @@
+import React, { useState, useEffect } from 'react'
+import PropTypes from 'prop-types'
+import {
+  Table,
+  TableBody,
+  TableHeader,
+  wrappable,
+  EditableTextCell,
+  cancelCellEdits,
+  applyCellEdits,
+  validateCellEdits,
+  cellWidth,
+} from '@patternfly/react-table'
+import { msg } from '_/intl-messages'
+
+const StorageConnectionsTable = ({
+  type,
+  connections,
+  isNewConnectionOpened,
+  setNewConnectionOpened,
+  storageDomain,
+  onCreate,
+  onEdit,
+  onDelete,
+  onAttach,
+  onDetach,
+}) => {
+  const columns = {
+    iscsi: [
+      {
+        title: msg.storageConnectionsTableColAttached(),
+        transforms: [wrappable, cellWidth(10)],
+      },
+      {
+        title: msg.storageConnectionsTableColAddress(),
+        transforms: [wrappable],
+      },
+      {
+        title: msg.storageConnectionsTableColPort(),
+        transforms: [wrappable, cellWidth(10)],
+      },
+      {
+        title: msg.storageConnectionsTableColTarget(),
+        transforms: [wrappable],
+      },
+    ],
+    // add column definitions for other types of connections here
+  }
+
+  const getColumns = () => {
+    return columns[type]
+  }
+
+  const createIScsiConnection = (row) => {
+    return {
+      address: getCellEditableValue(row.cells[1]),
+      port: getCellEditableValue(row.cells[2]),
+      target: getCellEditableValue(row.cells[3]),
+      type: type,
+    }
+  }
+
+  const connectionCreator = {
+    iscsi: createIScsiConnection,
+    // add implementations for connections creators here
+  }
+
+  const getConnectionFromRow = (row) => {
+    return connectionCreator[type](row)
+  }
+
+  const deleteConnection = (connection) => {
+    onDelete(connection.id)
+  }
+
+  const attachConnection = (connection) => {
+    onAttach(connection.id, storageDomain.id)
+  }
+
+  const detachConnection = (connection) => {
+    onDetach(connection.id, storageDomain.id)
+  }
+
+  const checkFieldsEdited = (row) => {
+    return row.cells.some(cell => cell.props.value !== cell.props.editableValue)
+  }
+
+  const updateRows = (evt, type, isEditable, rowIndex, validationErrs) => {
+    const newRows = Array.from(rows)
+    const connection = newRows[rowIndex].connection
+
+    switch (type) {
+      case 'edit':
+        replaceAttachedCellWithEmptyCell(newRows[rowIndex])
+        newRows[rowIndex] = applyCellEdits(newRows[rowIndex], type)
+        setRows(newRows)
+        break
+      case 'cancel':
+        if (isNewConnectionOpened && rowIndex === 0) {
+          setNewConnectionOpened(false)
+        } else {
+          newRows[rowIndex] = cancelCellEdits(newRows[rowIndex])
+          replaceAttachedCellWithIconCell(newRows[rowIndex], connection)
+          setRows(newRows)
+        }
+        break
+      case 'save': {
+        // Replacing the default PatternFly Table input validation mechanism
+        const validationErrors = validateRow(newRows[rowIndex])
+        if (validationErrors && Object.keys(validationErrors).length) {
+          newRows[rowIndex] = validateCellEdits(newRows[rowIndex], type, validationErrors)
+          setRows(newRows)
+        } else {
+          const newConnection = getConnectionFromRow(newRows[rowIndex])
+          if (isNewConnectionOpened && rowIndex === 0) {
+            setNewConnectionOpened(false)
+            onCreate(newConnection)
+          } else if (checkFieldsEdited(newRows[rowIndex])) {
+            onEdit(newConnection, connection.id)
+          } else {
+            newRows[rowIndex] = cancelCellEdits(newRows[rowIndex])
+            replaceAttachedCellWithIconCell(newRows[rowIndex], connection)
+            setRows(newRows)
+          }
+        }
+        break
+      }
+      default:
+        break
+    }
+  }
+
+  // This function replaces the regular PF Table input validation mechanism in Editable Cells, which
+  // as for now doesn't have an option to apply rules on separate cells, but rather only on all the cells in a row
+  // This function validates every cell according to cell.props.rules
+  // returns map (rule name => array of cell names that failed validation)
+  const validateRow = (row) => {
+    const validationErrors = {}
+
+    for (const cell of row.cells) {
+      const testValue = cell.props.editableValue === '' ? '' : cell.props.editableValue || cell.props.value
+      for (const rule of cell.props.rules) {
+        if (!rule.validator(testValue)) {
+          if (!validationErrors[rule.name]) {
+            validationErrors[rule.name] = []
+          }
+          validationErrors[rule.name].push(cell.props.name)
+        }
+      }
+    }
+
+    return validationErrors
+  }
+
+  const replaceAttachedCellWithEmptyCell = (row) => {
+    row.cells[0].props.value = ''
+  }
+
+  const replaceAttachedCellWithIconCell = (row, connection) => {
+    row.cells[0].props.value = getIsAttachedIcon(connection)
+  }
+
+  const handleTextInputChange = (newValue, evt, rowIndex, cellIndex) => {
+    setRows((oldRows) => {
+      const newRows = Array.from(oldRows)
+      newRows[rowIndex].cells[cellIndex].props.editableValue = newValue
+      return newRows
+    })
+  }
+
+  const createEditableTextCell = (val, isEditable, rules, rowIndex, cellIndex) => {
+    return ({
+      title: (value, rowIndex, cellIndex, props) => (
+        <EditableTextCell
+          value={value}
+          rowIndex={rowIndex}
+          cellIndex={cellIndex}
+          props={props}
+          isDisabled={!isEditable}
+          handleTextInputChange={handleTextInputChange}
+          inputAriaLabel='connection-property-input'
+        />
+      ),
+      props: {
+        value: val,
+        name: `row${rowIndex}cell${cellIndex}`,
+        rules: rules || [],
+      },
+    })
+  }
+
+  const getCellEditableValue = (cell) => {
+    return cell.props.editableValue
+  }
+
+  const createIScsiCells = (connection, rowIndex) => {
+    let cellIndex = 0
+    if (!connection) {
+      return [
+        createEditableTextCell('', false, [], rowIndex, cellIndex++),
+        createEditableTextCell('', true, [requiredRule], rowIndex, cellIndex++),
+        createEditableTextCell('', true, [requiredRule, portRule], rowIndex, cellIndex++),
+        createEditableTextCell('', true, [requiredRule], rowIndex, cellIndex++),
+      ]
+    }
+    const isEditAllowed = canEditConnection(connection, storageDomain)
+    return [
+      createEditableTextCell(getIsAttachedIcon(connection), false, [], rowIndex, cellIndex++),
+      createEditableTextCell(connection.address, isEditAllowed, [requiredRule], rowIndex, cellIndex++),
+      createEditableTextCell(connection.port, isEditAllowed, [requiredRule, portRule], rowIndex, cellIndex++),
+      createEditableTextCell(connection.target, isEditAllowed, [requiredRule], rowIndex, cellIndex++),
+    ]
+  }
+
+  const cellsCreator = {
+    iscsi: createIScsiCells,
+    // add implementations for cells creators here
+  }
+
+  const getIsAttachedIcon = (connection) => {
+    return connection.isAttachedToDomain ? <i className='fa fa-check' /> : ''
+  }
+
+  const createRows = (type, connections) => {
+    const rows = []
+    connections.forEach((connection, index) => {
+      rows.push(createRow(type, connection, true, index + 1))
+    })
+    if (isNewConnectionOpened) {
+      rows.unshift(createRow(type, null, false, 0))
+      rows[0] = applyCellEdits(rows[0], 'edit', false)
+    }
+    return rows
+  }
+
+  const createRow = (type, connection, areActionsEnabled, rowIndex) => {
+    const createCells = cellsCreator[type]
+    return {
+      cells: createCells(connection, rowIndex),
+      connection: connection,
+      isHoverable: true,
+      disableActions: !areActionsEnabled,
+      rowEditValidationRules: validationRules,
+    }
+  }
+
+  const actionResolver = (rowData, _) => {
+    return [
+      {
+        title: msg.storageConnectionsAttachConnectionButton(),
+        onClick: (event, rowId, rowData, extra) => attachConnection(rowData.connection),
+        isDisabled: rowData.connection && !canAttachConnection(rowData.connection, storageDomain),
+      },
+      {
+        title: msg.storageConnectionsDetachConnectionButton(),
+        onClick: (event, rowId, rowData, extra) => detachConnection(rowData.connection),
+        isDisabled: rowData.connection && !canDetachConnection(rowData.connection, storageDomain),
+      },
+      {
+        title: msg.storageConnectionsRemoveConnectionButton(),
+        onClick: (event, rowId, rowData, extra) => deleteConnection(rowData.connection),
+        isDisabled: rowData.connection && !canRemoveConnection(rowData.connection),
+      },
+    ]
+  }
+
+  const requiredRule = {
+    name: 'required',
+    validator: val => val.trim() !== '',
+    errorText: msg.storageConnectionsFieldRequiredError(),
+  }
+
+  const portRule = {
+    name: 'port',
+    validator: val => val > 0 && val <= 0xFFFF,
+    errorText: msg.storageConnectionsFieldPortError(),
+  }
+
+  const validationRules = [requiredRule, portRule]
+
+  const [rows, setRows] = useState(createRows(type, connections))
+  useEffect(() => {
+    const newRows = createRows(type, connections)
+    setRows(newRows)
+  }, [connections, isNewConnectionOpened])
+
+  return (
+    <Table
+      aria-label='Storage Connections Table'
+      className='storage-connections-table'
+      cells={getColumns()}
+      rows={rows}
+      onRowEdit={updateRows}
+      variant='compact'
+      actionResolver={actionResolver}
+      areActionsDisabled={rowData => !!rowData.disableActions}
+      dropdownPosition="left"
+      dropdownDirection="down"
+    >
+      <TableHeader />
+      <TableBody />
+    </Table>
+  )
+}
+
+const canEditConnection = (connection, storageDomain) => {
+  return connection && (!connection.isAttachedToDomain || storageDomain.status === 'maintenance')
+}
+
+const canAttachConnection = (connection, storageDomain) => {
+  return connection && (!connection.isAttachedToDomain && storageDomain.status === 'maintenance')
+}
+
+const canDetachConnection = (connection, storageDomain) => {
+  return connection && (connection.isAttachedToDomain && storageDomain.status === 'maintenance')
+}
+
+const canRemoveConnection = (connection) => {
+  return connection && (!connection.isAttachedToDomain)
+}
+
+StorageConnectionsTable.propTypes = {
+  type: PropTypes.string,
+  connections: PropTypes.array,
+  isNewConnectionOpened: PropTypes.bool,
+  setNewConnectionOpened: PropTypes.func,
+  storageDomain: PropTypes.object,
+  onCreate: PropTypes.func,
+  onEdit: PropTypes.func,
+  onDelete: PropTypes.func,
+  onAttach: PropTypes.func,
+  onDetach: PropTypes.func,
+}
+
+export default StorageConnectionsTable

--- a/src/modals/storage-connections/connections.css
+++ b/src/modals/storage-connections/connections.css
@@ -1,0 +1,13 @@
+.storage-connections-modal {
+    min-height: 700px;
+}
+.storage-connections-table th.pf-c-table__sort {
+    padding-top: var(--pf-c-table-cell--PaddingTop);
+    padding-right: var(--pf-c-table-cell--PaddingRight);
+    padding-bottom: var(--pf-c-table-cell--PaddingBottom);
+    padding-left: var(--pf-c-table-cell--PaddingLeft);
+}
+
+.storage-connections-table ul {
+    list-style: none;
+}

--- a/src/utils/fetch.js
+++ b/src/utils/fetch.js
@@ -46,10 +46,6 @@ export async function enginePost (relativePath, body, extraHeaders) {
   return engineApiRequest('POST', relativePath, body, extraHeaders)
 }
 
-export async function engineDelete (relativePath) {
-  return engineApiRequest('DELETE', relativePath)
-}
-
 /**
  * Initiate Engine HTTP `PUT` request, expecting JSON response.
  *
@@ -61,6 +57,18 @@ export async function engineDelete (relativePath) {
  */
 export async function enginePut (relativePath, body, extraHeaders) {
   return engineApiRequest('PUT', relativePath, body, extraHeaders)
+}
+
+/**
+ * Initiate Engine HTTP `DELETE` request, expecting JSON response.
+ *
+ * @example
+ * ```
+ * const json = await engineDelete(`api/vms/${vmId}`)
+ * ```
+ */
+export async function engineDelete (relativePath, extraHeaders) {
+  return engineApiRequest('DELETE', relativePath, null, extraHeaders)
 }
 
 /**


### PR DESCRIPTION
Storage Connections management dialog is opened by clicking the
Connections button in the Storage Domains table when iSCSI Storage
Domain is selected.

The dialog displays storage connections, attached to the domain, and
also has a switch to show all the iSCSI connections. It allows 5
actions to be performed on the connections:
1. Add new connection
2. Edit connection
3. Remove connection
4. Attach connection to the domain
5. Detach connection from the domain
Which provides UI for the existing storage connections API
Live changes are not supported, thus the domain should be in
maintenance mode to perform actions (4),(5), and also (2),(3) for
attached connections

Bug: https://bugzilla.redhat.com/show_bug.cgi?id=977379
![Screenshot from 2022-02-15 14-24-01](https://user-images.githubusercontent.com/87977971/154064140-c1f8ee02-88b1-4931-a99b-d6cd84fc5b5b.png)
![Screenshot from 2022-02-15 14-25-37](https://user-images.githubusercontent.com/87977971/154064143-8ed3d261-8468-4ff3-8e45-52159e601d1a.png)
![Screenshot from 2022-02-15 14-26-03](https://user-images.githubusercontent.com/87977971/154064145-35dd3f9c-7aac-4ab7-9506-efebc157db7c.png)
![Screenshot from 2022-02-15 14-26-22](https://user-images.githubusercontent.com/87977971/154064149-71be4610-841a-47aa-bcef-7dd304a33a45.png)
![Screenshot from 2022-02-15 14-26-40](https://user-images.githubusercontent.com/87977971/154064150-298fc8e9-9f10-4c58-98d0-76a3c0061662.png)
.