### PR TITLE
Add link to Monitoring Portal on Dashboard

### DIFF
--- a/src/dashboard/Dashboard.js
+++ b/src/dashboard/Dashboard.js
@@ -5,6 +5,7 @@ import { dashboardDataShape } from './dataShapes'
 import { Stack, StackItem, Flex, FlexItem } from '@patternfly/react-core'
 import RefreshDataControl from './RefreshDataControl'
 import LastUpdatedLabel from './LastUpdatedLabel'
+import MonitoringPortalLink from './MonitoringPortalLink'
 import InventoryStatusCards from './InventoryStatusCards'
 import GlobalUtilizationCards from './GlobalUtilizationCards'
 import HeatMapCards from './HeatMapCards'
@@ -15,7 +16,7 @@ const Dashboard = ({ data, lastUpdated, onRefreshData }) => {
     return null
   }
 
-  const { inventory, globalUtilization, heatMapData } = data
+  const { inventory, globalUtilization, heatMapData, engineGrafanaBaseUrl } = data
   const showGluster = inventory.volume.totalCount > 0
 
   return (
@@ -27,6 +28,9 @@ const Dashboard = ({ data, lastUpdated, onRefreshData }) => {
           </FlexItem>
           <FlexItem>
             <LastUpdatedLabel date={lastUpdated} />
+          </FlexItem>
+          <FlexItem align={{ default: 'alignRight' }}>
+            <MonitoringPortalLink url={engineGrafanaBaseUrl} />
           </FlexItem>
         </Flex>
       </StackItem>

--- a/src/dashboard/MonitoringPortalLink.js
+++ b/src/dashboard/MonitoringPortalLink.js
@@ -1,0 +1,15 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { msg } from '_/intl-messages'
+
+const MonitoringPortalLink = ({ url }) => {
+  return url && (
+    <a className='monitoring-portal-link' target='_top' href={url}>{msg.dashboardLinkMonitoringPortal()}</a>
+  )
+}
+
+MonitoringPortalLink.propTypes = {
+  url: PropTypes.string,
+}
+
+export default MonitoringPortalLink

--- a/src/dashboard/dataShapes.js
+++ b/src/dashboard/dataShapes.js
@@ -59,4 +59,5 @@ export const dashboardDataShape = {
     storage: heatMapDataArray,
     vdoSavings: heatMapDataArray,
   }),
+  engineGrafanaBaseUrl: PropTypes.string,
 }

--- a/src/intl/messages.js
+++ b/src/intl/messages.js
@@ -162,6 +162,12 @@ const messageDescriptors = {
     description: 'label that indicates date/time of last dashboard data update',
   },
 
+  dashboardLinkMonitoringPortal: {
+    id: 'dashboard.linkMonitoringPortal',
+    defaultMessage: 'Monitoring Portal',
+    description: 'if Grafana is installed, show a link to Grafana portal, same as on the engine welcome page',
+  },
+
   dashboardGlobalUtilizationHeading: {
     id: 'dashboard.globalUtilizationHeading',
     defaultMessage: 'Global Utilization',

--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -12,14 +12,14 @@ body, .containers-dashboard {
   /* dashboard CSS variables */
   --dashboard-gutter: var(--pf-global--spacer--sm);
   --dashboard-aggregate-status-header-FontSize: 14px;
-  --dashboard-aggregate-status-header-FontWeight: var(--pf-globale--FontWeight--normal);
+  --dashboard-aggregate-status-header-FontWeight: var(--pf-global--FontWeight--normal);
   --dashboard-aggregate-status-notifications-FontSize: calc(var(--pf-global--FontSize--lg) + 10px);
 
   --dashboard-cards-header-FontSize: 16px;
-  --dashboard-cards-header-FontWeight: var(--pf-globale--FontWeight--normal);
+  --dashboard-cards-header-FontWeight: var(--pf-global--FontWeight--normal);
 
   --dashboard-chart-title-FontSize: var(--pf-global--FontSize--lg);
-  --dashboard-chart-title-FontWeight: var(--pf-globale--FontWeight--normal);
+  --dashboard-chart-title-FontWeight: var(--pf-global--FontWeight--normal);
 }
 
 .pf-c-tooltip {
@@ -34,9 +34,9 @@ body, .containers-dashboard {
 }
 
 .monitoring-portal-link {
-  line-height: 1.5;
-  font-weight: 600;
-  font-size: 16px;
+  line-height: var(--pf-global--LineHeight--md);
+  font-weight: var(--pf-global--FontWeight--bold);
+  font-size: var(--pf-global--FontSize--lg);
 }
 
 /* Aggregate status card */

--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -34,7 +34,6 @@ body, .containers-dashboard {
 }
 
 .monitoring-portal-link {
-  /* font-family: RedHatDisplay; */
   line-height: 1.5;
   font-weight: 600;
   font-size: 16px;

--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -33,6 +33,12 @@ body, .containers-dashboard {
   --pf-l-stack--m-gutter--MarginBottom: var(--dashboard-gutter);
 }
 
+.monitoring-portal-link {
+  /* font-family: RedHatDisplay; */
+  line-height: 1.5;
+  font-weight: 600;
+  font-size: 16px;
+}
 
 /* Aggregate status card */
 .aggregate-status-card {


### PR DESCRIPTION
If the URL for the engine's grafana instance is available from the `dashboard_data` fetch, render the link in the upper right
hand side of the dashboard.  This allows the user to click directly to the monitoring portal without jumping back to the welcome page first.

If no URL is provided from the `dashboard_data`fetch, no link is rendered.

Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=1991482
Require ovirt-engine PR: https://github.com/oVirt/ovirt-engine/pull/85

Here is the link on the dashboard:
![screenshot-engine-dev ovirt_8080-2022 03 02-13_29_49](https://user-images.githubusercontent.com/3985964/156425426-631926ce-82fc-4b52-8938-9ecd703193e5.png)

