### PR TITLE
Bump version to 1.3.0 for ovirt 4.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ovirt-engine-ui-extensions",
-  "version": "1.2.7",
+  "version": "1.3.0",
   "description": "UI plugin that provides various extensions to oVirt administration UI, such as dashboard, migrate vm, and cluster upgrade",
   "license": "Apache-2.0",
   "repository": {

--- a/packaging/spec.in
+++ b/packaging/spec.in
@@ -18,14 +18,14 @@ BuildRequires: rpm-build
 
 %if %{offline_build}
 # nodejs-modules embeds yarn and requires nodejs
-BuildRequires: ovirt-engine-nodejs-modules >= 2.1.6-1
+BuildRequires: ovirt-engine-nodejs-modules >= 2.2.0-1
 %else
 BuildRequires: nodejs >= 14.15
 BuildRequires: yarn >= 1.22
 %endif
 
-Requires: ovirt-engine-webadmin-portal >= 4.3
-Requires: ovirt-ansible-collection >= 1.2.0
+Requires: ovirt-engine-webadmin-portal >= 4.5
+Requires: ovirt-ansible-collection >= 2.0
 
 Obsoletes: ovirt-engine-dashboard < 1.3
 Provides: ovirt-engine-dashboard = 1.3
@@ -37,6 +37,7 @@ Extensions include:
   - Dashboard
   - Cluster upgrade wizard
   - Host copy network dialog
+  - VM CPU pinning dialog
   - VM export dialog
   - VM manage GPU dialog
   - VM migrate dialog

--- a/zanata/zanata.xml
+++ b/zanata/zanata.xml
@@ -2,7 +2,7 @@
 <config xmlns="http://zanata.org/namespace/config/">
     <url>https://zanata.ovirt.org/</url>
     <project>ovirt-engine-ui-extensions</project>
-    <project-version>1.2</project-version>
+    <project-version>1.3</project-version>
     <project-type>gettext</project-type>
 
     <src-dir>../extra/messages</src-dir>


### PR DESCRIPTION
To keep translations and ansible dependencies between ovirt 4.4 (project version 1.2) and ovirt 4.5 separate, bump the project version to 1.3.

Update the project dependencies based on a ovirt 4.5 target.

The zanata project version has been updated accordingly:
 - Translations for ovirt 4.4 / project 1.2 are at: https://zanata.ovirt.org/iteration/view/ovirt-engine-ui-extensions/1.2
 - Translations for ovirt 4.5 / project 1.3 are at: https://zanata.ovirt.org/iteration/view/ovirt-engine-ui-extensions/1.3