### PR TITLE
Export VM: move button to kebab menu and rename button label

### DIFF
--- a/src/integrations/buttons.js
+++ b/src/integrations/buttons.js
@@ -95,8 +95,9 @@ function addVmExportButton () {
       )
     },
 
-    index: 4,
+    index: 13,
     id: 'VmExport',
+    moreMenu: true,
   })
 }
 

--- a/src/intl/messages.js
+++ b/src/intl/messages.js
@@ -734,7 +734,7 @@ const messageDescriptors = {
   },
   exportVmButton: {
     id: 'export.vm.buttonLabel',
-    defaultMessage: 'Export',
+    defaultMessage: 'Export to Data Domain',
     description: 'label of `Export` button in VM export dialog',
   },
   exportedVmNameTextFieldLabel: {

--- a/src/plugin-api.d.ts
+++ b/src/plugin-api.d.ts
@@ -106,6 +106,11 @@ interface ActionButtonInterface {
    */
   id?: string;
 
+  /**
+   * Determines if the action button will be a menu item in the 'more items'
+   * (kebab) menu of the action panel
+   */
+   moreMenu?: Boolean;
 }
 
 interface OvirtLogger {


### PR DESCRIPTION
move the 'Export' button to kebab menu along with other export VM
options and change button label text to 'Export to Data Domain'.

![image](https://user-images.githubusercontent.com/18169498/158180155-5f80bc32-66ac-4eac-b048-4835599f16c4.png)


Bug-Url: https://bugzilla.redhat.com/1979052