### PR TITLE
github action: build on push to master or add release label

### DIFF
--- a/.github/workflows/build-master.yaml
+++ b/.github/workflows/build-master.yaml
@@ -1,0 +1,31 @@
+name: run build on master
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - ovirt-engine-ui-extensions-*
+  workflow_dispatch:
+
+jobs:
+  build_el8_offline:
+    name: EL8 - build and publish rpm repo for the PR (ovirt-engine-nodejs-modules build)
+    env:
+      OFFLINE_BUILD: 1
+
+    runs-on: ubuntu-latest
+    container:
+      image: quay.io/ovirt/buildcontainer:el8stream
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Run packaging/build.sh
+        run: |
+          ./packaging/build.sh
+
+      - name: Upload artifacts as rpm repo
+        uses: ovirt/upload-rpms-action@v2
+        with:
+          directory: exported-artifacts/


### PR DESCRIPTION
Replicating the copr build in github actions.  When commits are
pushed to master, or when a label with the release format is pushed
to master, run a build.