### PR TITLE
github actions: always upgrade nodejs-modules

### DIFF
--- a/.github/workflows/build-master.yaml
+++ b/.github/workflows/build-master.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build_el8_offline:
-    name: EL8 - build and publish rpm repo for the PR (ovirt-engine-nodejs-modules build)
+    name: EL8 - build and publish rpm repo (ovirt-engine-nodejs-modules build)
     env:
       OFFLINE_BUILD: 1
 
@@ -18,6 +18,10 @@ jobs:
       image: quay.io/ovirt/buildcontainer:el8stream
 
     steps:
+      - name: Ensure latest ovirt-engine-nodejs-modules is installed
+        run: |
+          dnf -y --disablerepo='*' --enablerepo='*ovirt*' upgrade ovirt-engine-nodejs-modules
+
       - name: Checkout sources
         uses: actions/checkout@v2
 

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -16,6 +16,10 @@ jobs:
       image: quay.io/ovirt/buildcontainer:el8stream
 
     steps:
+      - name: Ensure latest ovirt-engine-nodejs-modules is installed
+        run: |
+          dnf -y --disablerepo='*' --enablerepo='*ovirt*' upgrade ovirt-engine-nodejs-modules
+
       - name: Checkout sources
         uses: actions/checkout@v2
 
@@ -35,6 +39,10 @@ jobs:
       image: quay.io/ovirt/buildcontainer:el8stream
 
     steps:
+      - name: Ensure latest ovirt-engine-nodejs-modules is installed
+        run: |
+          dnf -y --disablerepo='*' --enablerepo='*ovirt*' upgrade ovirt-engine-nodejs-modules
+
       - name: Checkout sources
         uses: actions/checkout@v2
 


### PR DESCRIPTION
Since we use the ovirt buildcontainer[1] with `ovirt-engine-nodejs-modules`
already installed, there is a gap in time from when we update
nodejs-modules and when it becomes available in the container.  The container
builds at least once a day.

To facilitate our use of nodejs-modules and allow us to use pre-seed
updates as soon as they are available in copr, the github actions are
updated to always `dnf upgrade` the package.  If no upgrades are available,
the operation will take very little time.

[1] - https://github.com/oVirt/buildcontainer