### PR TITLE
Fix `renderComponent()` to minimize CSS flashing

### DIFF
--- a/src/components/modals/PluginApiModal.js
+++ b/src/components/modals/PluginApiModal.js
@@ -20,23 +20,26 @@ const PluginApiModal = ({
       const clonedStyles = []
 
       if (window !== modalContext.targetWindow) {
+        const cssTop = []
+        const cssBottom = []
+
         window.document.querySelectorAll('head style, head link[type="text/css"], head link[rel="stylesheet"]').forEach(style => {
           const cloned = style.cloneNode(true)
           cloned.setAttribute('data-style-for', id)
           clonedStyles.push(cloned)
 
           if (/ui-extensions\/css\/vendor\.[^/]*?css$/.test(cloned.href)) {
-            modalContext.prependCss(cloned)
+            cssTop.push(cloned)
           } else {
-            modalContext.appendCss(cloned)
+            cssBottom.push(cloned)
           }
         })
+
+        modalContext.applyCss(cssTop, cssBottom)
       }
 
       return () => {
-        clonedStyles.forEach(style => {
-          modalContext.removeCss(style)
-        })
+        modalContext.removeCss(clonedStyles)
       }
     }
   }, [isOpen, id, modalContext])

--- a/src/components/modals/PluginApiModal.js
+++ b/src/components/modals/PluginApiModal.js
@@ -13,6 +13,10 @@ const PluginApiModal = ({
   onClose = () => {},
   ...restForModal
 }) => {
+  // Note: The `WebAdminModalContext` is only created once per action button click
+  //       and once when the Dashboard place is loaded.  Once created it will be stable
+  //       for the entire modal (or dashboard) app instance.  See `renderComponent()`
+  //       and `src/utils/react-modals.js` in general for more details.
   const modalContext = useContext(WebAdminModalContext)
 
   useEffect(() => {

--- a/src/components/modals/PluginApiModal.js
+++ b/src/components/modals/PluginApiModal.js
@@ -17,29 +17,10 @@ const PluginApiModal = ({
 
   useEffect(() => {
     if (isOpen) {
-      const clonedStyles = []
-
-      if (window !== modalContext.targetWindow) {
-        const cssTop = []
-        const cssBottom = []
-
-        window.document.querySelectorAll('head style, head link[type="text/css"], head link[rel="stylesheet"]').forEach(style => {
-          const cloned = style.cloneNode(true)
-          cloned.setAttribute('data-style-for', id)
-          clonedStyles.push(cloned)
-
-          if (/ui-extensions\/css\/vendor\.[^/]*?css$/.test(cloned.href)) {
-            cssTop.push(cloned)
-          } else {
-            cssBottom.push(cloned)
-          }
-        })
-
-        modalContext.applyCss(cssTop, cssBottom)
-      }
+      modalContext.applyCss(id)
 
       return () => {
-        modalContext.removeCss(clonedStyles)
+        modalContext.removeCss(id)
       }
     }
   }, [isOpen, id, modalContext])

--- a/src/dashboard/UtilizationDialog.js
+++ b/src/dashboard/UtilizationDialog.js
@@ -21,10 +21,11 @@ const UtilizationDialog = ({
   thresholds,
 }) => (
   <PluginApiModal
+    id='over-utilization-dialog'
+    className='overutilization-dialog'
     isOpen={show}
     onClose={onClose}
     title={title}
-    className='overutilization-dialog'
     aria-label={`utilization dialog ${title}`}
     header={(
       <Title headingLevel='h1' size='xl'>

--- a/src/integrations/showStorageConnectionsModal.js
+++ b/src/integrations/showStorageConnectionsModal.js
@@ -12,6 +12,7 @@ export function showStorageConnectionsModal (storageDomain) {
           onClose={unmountComponent}
         />
       </StorageConnectionsDataProvider>
-    )
+    ),
+    'show-storage-connections-modal'
   )
 }

--- a/src/modals/cluster-upgrade/ClusterUpgradeModal.js
+++ b/src/modals/cluster-upgrade/ClusterUpgradeModal.js
@@ -56,6 +56,7 @@ const ClusterUpgradeModal = ({
   if (isLoading) {
     return (
       <PluginApiModal
+        id='cluster-upgrade-modal'
         className='clusterUpgradeWizardModal'
         title={msg.clusterUpgradeLoadingTitle()}
         variant='small'
@@ -84,6 +85,7 @@ const ClusterUpgradeModal = ({
   if (isClusterInMaintenace && !confirmedClusterPolicy) {
     return (
       <PluginApiModal
+        id='cluster-upgrade-modal'
         className='clusterUpgradeWizardModal'
         title={msg.clusterUpgradeTitle({ clusterName: cluster.name })}
         variant='small'
@@ -122,6 +124,7 @@ const ClusterUpgradeModal = ({
   // Modal is open, all data is loaded, and the cluster is available to be upgraded
   return (
     <PluginApiModal
+      id='cluster-upgrade-modal'
       className='clusterUpgradeWizardModal'
       variant='large'
       isOpen={isOpen}

--- a/src/modals/cpu-pinning/CpuPinningModal.js
+++ b/src/modals/cpu-pinning/CpuPinningModal.js
@@ -28,9 +28,9 @@ const CpuPinningModal = ({
   }
   return (
     <PluginApiModal
+      id='cpu-pinning-modal'
       variant={variant}
       title={msg.cpuPinningModalTitle()}
-      id='CpuPinningModal'
       isOpen={isModalOpen}
       onClose={handleCloseModal}
       actions={[

--- a/src/modals/host-copy-network/HostCopyNetworksModal.js
+++ b/src/modals/host-copy-network/HostCopyNetworksModal.js
@@ -57,6 +57,7 @@ const HostCopyNetworksModal = ({
 
   return (
     <PluginApiModal
+      id='host-copy-network-modal'
       variant='large'
       title={msg.hostCopyNetworksDialogTitle()}
       isOpen={isOpen}

--- a/src/modals/storage-connections/StorageConnectionsModal.js
+++ b/src/modals/storage-connections/StorageConnectionsModal.js
@@ -102,6 +102,7 @@ const StorageConnectionsModal = ({
 
   return (
     <PluginApiModal
+      id='storage-connections-modal'
       className='storage-connections-modal'
       variant='large'
       title={

--- a/src/modals/vm-export/VmExportModal.js
+++ b/src/modals/vm-export/VmExportModal.js
@@ -72,6 +72,7 @@ const VmExportModal = ({
 
   return (
     <PluginApiModal
+      id='vm-export-modal'
       variant='large'
       title={msg.exportVmTitle()}
       isOpen={isOpen}

--- a/src/modals/vm-manage-gpu/ManageGpuModal.js
+++ b/src/modals/vm-manage-gpu/ManageGpuModal.js
@@ -89,6 +89,7 @@ const ManageGpuModal = ({
 
   return (
     <PluginApiModal
+      id='vm-manage-gpu-modal'
       className='vgpu-modal'
       variant='large'
       title={msg.vmManageGpuDialogTitle()}

--- a/src/modals/vm-manage-gpu/ManageGpuModalBody.js
+++ b/src/modals/vm-manage-gpu/ManageGpuModalBody.js
@@ -116,7 +116,7 @@ const ManageGpuModalBody = ({
             )}
           </DescriptionListDescription>
         </DescriptionListGroup>
-        </DescriptionList>
+      </DescriptionList>
 
       {
         !gpusAvailable && (

--- a/src/modals/vm-migrate/VmMigrateModal.js
+++ b/src/modals/vm-migrate/VmMigrateModal.js
@@ -70,6 +70,7 @@ const VmMigrateModal = ({
 
   return (
     <PluginApiModal
+      id='vm-migrate-modal'
       variant='large'
       title={msg.migrateVmDialogTitle()}
       isOpen={isOpen}

--- a/src/utils/react-modals.js
+++ b/src/utils/react-modals.js
@@ -56,6 +56,9 @@ function createModalContextValue (
   }
 }
 
+/*
+ * The default context value supports Dashboard (places integration) based modals.
+ */
 export const WebAdminModalContext = React.createContext(createModalContextValue())
 WebAdminModalContext.displayName = 'WebAdminModalContext'
 
@@ -75,7 +78,7 @@ export const renderComponent = (render, id) => {
   if (!container) {
     container = targetWindow.document.createElement('div')
     container.setAttribute('id', id)
-    container.setAttribute('class', 'ui-extensions-plugin-approot')
+    container.setAttribute('class', 'ui-extensions-plugin-approot') // marker class
     targetWindow.document.body.appendChild(container)
   }
 

--- a/src/utils/react-modals.js
+++ b/src/utils/react-modals.js
@@ -1,8 +1,36 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import { getWebAdminWindow } from './webadmin-dom'
+import { getWebAdminWindow, getWebAdminDocumentBody } from './webadmin-dom'
 
-export const WebAdminModalContext = React.createContext()
+function createModalContextValue (
+  targetWindow = getWebAdminWindow(),
+  targetContainer = getWebAdminDocumentBody(),
+  cssContainer
+) {
+  cssContainer = cssContainer || targetWindow.document.head
+
+  return {
+    targetWindow,
+    targetContainer,
+
+    applyCss: (beforeCssNodes, afterCssNodes) => {
+      for (const cssNode of beforeCssNodes) {
+        cssContainer.insertBefore(cssNode, cssContainer.firstChild)
+      }
+      for (const cssNode of afterCssNodes) {
+        cssContainer.appendChild(cssNode)
+      }
+    },
+
+    removeCss: (cssNodes) => {
+      for (const cssNode of cssNodes) {
+        cssContainer.removeChild(cssNode)
+      }
+    },
+  }
+}
+
+export const WebAdminModalContext = React.createContext(createModalContextValue())
 WebAdminModalContext.displayName = 'WebAdminModalContext'
 
 export const renderComponent = (render, id) => {
@@ -31,19 +59,7 @@ export const renderComponent = (render, id) => {
 
   ReactDOM.render(
     <WebAdminModalContext.Provider
-      value={{
-        targetWindow,
-        targetContainer: container,
-        prependCss: (cssNode) => {
-          targetWindow.document.head.insertBefore(cssNode, targetWindow.document.head.firstChild)
-        },
-        appendCss: (cssNode) => {
-          targetWindow.document.head.appendChild(cssNode)
-        },
-        removeCss: (cssNode) => {
-          targetWindow.document.head.removeChild(cssNode)
-        },
-      }}
+      value={createModalContextValue(targetWindow, container)}
     >
       {render({ unmountComponent })}
     </WebAdminModalContext.Provider>,

--- a/src/utils/react-modals.js
+++ b/src/utils/react-modals.js
@@ -1,79 +1,52 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import uniqueId from 'lodash/uniqueId'
-
 import { getWebAdminWindow } from './webadmin-dom'
 
 export const WebAdminModalContext = React.createContext()
 WebAdminModalContext.displayName = 'WebAdminModalContext'
 
-/**
- * Render patternfly-react `Modal` based component into WebAdmin document body.
- *
- * @example
- * ```
- * showModal(({ container, destroyModal }) => (
- *   <MyModal show container={container} onExited={destroyModal} />
- * ))
- * ```
- */
-export const showModal = (modalCreator, modalId = uniqueId()) => {
+export const renderComponent = (render, id) => {
   const targetWindow = getWebAdminWindow()
 
-  const modalContainer = targetWindow.document.createElement('div')
-  modalContainer.setAttribute('id', `showModal-${modalId}`)
-
-  targetWindow.document.body.appendChild(modalContainer)
-
-  const clonedStyles = []
-  if (window !== targetWindow) {
-    window.document.querySelectorAll('head style, head link[type="text/css"], head link[rel="stylesheet"]').forEach(style => {
-      const cloned = style.cloneNode(true)
-      cloned.setAttribute('data-style-for', `showModal-${modalId}`)
-      clonedStyles.push(cloned)
-
-      if (/ui-extensions\/css\/vendor\.[^/]*?css$/.test(cloned.href)) {
-        targetWindow.document.head.insertBefore(cloned, targetWindow.document.head.firstChild)
-      } else {
-        targetWindow.document.head.appendChild(cloned)
-      }
-    })
+  let container = targetWindow.document.querySelector(`div#${id}`)
+  if (!container) {
+    container = targetWindow.document.createElement('div')
+    container.setAttribute('id', id)
+    container.setAttribute('class', 'ui-extensions-container')
+    targetWindow.document.body.appendChild(container)
   }
 
-  const destroyModal = () => {
-    ReactDOM.unmountComponentAtNode(modalContainer)
-    targetWindow.document.body.removeChild(modalContainer)
-    clonedStyles.forEach(style => {
-      targetWindow.document.head.removeChild(style)
-    })
-  }
+  /*
+    Unmount the rendered component but give any Portal that may have been opened
+    a chance to close before doing so.  Since `PluginApiModal` will Portal itself
+    to `container`, it needs to unmount the Portal before the component is
+    unmounted.  This avoid an error message from react.
+   */
+  const unmountComponent = () =>
+    setTimeout(() => {
+      const container = targetWindow.document.querySelector(`div#${id}`)
+      ReactDOM.unmountComponentAtNode(container)
+      targetWindow.document.body.removeChild(container)
+    }, 0)
 
   ReactDOM.render(
     <WebAdminModalContext.Provider
       value={{
-        window: targetWindow,
-        modalContainer,
-        destroyModal,
+        targetWindow,
+        targetContainer: container,
+        prependCss: (cssNode) => {
+          targetWindow.document.head.insertBefore(cssNode, targetWindow.document.head.firstChild)
+        },
+        appendCss: (cssNode) => {
+          targetWindow.document.head.appendChild(cssNode)
+        },
+        removeCss: (cssNode) => {
+          targetWindow.document.head.removeChild(cssNode)
+        },
       }}
     >
-      {modalCreator({ container: modalContainer, destroyModal })}
+      {render({ unmountComponent })}
     </WebAdminModalContext.Provider>,
-    modalContainer
+    container
   )
-}
-
-export const renderComponent = (render, id = `component-${uniqueId()}`) => {
-  let container = document.querySelector(`div#${id}`)
-  if (!container) {
-    container = document.createElement('div')
-    container.setAttribute('id', id)
-    document.body.appendChild(container)
-  }
-
-  const unmountComponent = () => {
-    ReactDOM.unmountComponentAtNode(container)
-    document.body.removeChild(container)
-  }
-
-  ReactDOM.render(render({ unmountComponent }), container)
 }


### PR DESCRIPTION
## Description
Originally the `PluginApiModal` component used an unique and auto-generated string for the component's id.  This caused render issues for all modals since the `id` param would be changed each time any other props of the component would change.  The `id` change would then trigger the modal's CSS add/remove `useEffect`.

It was functional but caused lots of strange render issues.  The issue is quite prominent in Chrome.  Firefox doesn't have the same issue as it seems to handle CSS link changes much better.

The fix is to make the `id` static and required for each use.

Additional refactoring was done to keep the code that interacts with the hosting webadmin page all in the same place.  `renderComponent()` is now in charge of where CSS get added to the hosting document.

## Summary of changes
  - remove `showModal()` since it isn't used anymore
  - require the `id` param for `renderComponent()`
  - use `WebAdminModalContext` in `renderComponent()`
  - require the `id` param for `PluginApiModal`
  - add an explicit `id` for every use of `PluginApiModal`
  - `PluginApiModal` uses `WebAdminModalContext`

## Example
On Chrome Before:
![ezgif com-gif-maker (2)](https://user-images.githubusercontent.com/3985964/161302513-9fec6268-f7ff-49b6-a8ec-79c7d471c112.gif)

On Chrome After:
![ezgif com-gif-maker (3)](https://user-images.githubusercontent.com/3985964/161304909-e7f7534d-c8c7-4594-886c-d01368faf7f8.gif)

## References
Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=2073005

