### PR TITLE
vGPU: Show widgets even if no vGPU host found

### DIFF
--- a/src/modals/vm-manage-gpu/ManageGpuModal.js
+++ b/src/modals/vm-manage-gpu/ManageGpuModal.js
@@ -99,7 +99,7 @@ const ManageGpuModal = ({
           key='manage-gpu-select-button'
           variant='primary'
           onClick={onSelect}
-          isDisabled={gpus.length === 0}
+          isDisabled={gpus.length === 0 && !nonExistingSelectedMdevs?.length}
         >
           {msg.saveButton()}
         </Button>,

--- a/src/modals/vm-manage-gpu/ManageGpuModalBody.js
+++ b/src/modals/vm-manage-gpu/ManageGpuModalBody.js
@@ -38,18 +38,6 @@ const ManageGpuModalBody = ({
     setSearchText(value)
   }
 
-  if (gpus.length === 0) {
-    return (
-      <Bullseye>
-        <EmptyState variant={EmptyStateVariant.large}>
-          <EmptyStateIcon icon={SearchIcon} />
-          <Title headingLevel='h5' size='lg'>{msg.vmManageGpuEmptyStateTitle()}</Title>
-          <EmptyStateBody>{msg.vmManageGpuEmptyStateBody()}</EmptyStateBody>
-        </EmptyState>
-      </Bullseye>
-    )
-  }
-
   const selectedMDevType = Object.keys(selectedMDevTypes).find(mDevType => selectedMDevTypes[mDevType] > 0)
 
   const selectedMDevTypeInstances = []
@@ -65,6 +53,7 @@ const ManageGpuModalBody = ({
       gpu.host.toLowerCase().includes(searchText.toLowerCase()))
 
   const driverParamsEnabled = compatibilityVersion >= CompatibilityVersion.VERSION_4_7
+  const gpusAvailable = gpus.length > 0
 
   return (
     <div>
@@ -83,6 +72,7 @@ const ManageGpuModalBody = ({
               labelOff={msg.vmManageGpuBodyDisplaySwitchOff()}
               isChecked={displayOn}
               onChange={value => onDisplayOnChange(value)}
+              isDisabled={!gpusAvailable}
             />
           </DescriptionListDescription>
         </DescriptionListGroup>
@@ -94,7 +84,7 @@ const ManageGpuModalBody = ({
             <TextInput
               value={driverParams || ''}
               type='text'
-              isDisabled={!driverParamsEnabled}
+              isDisabled={!driverParamsEnabled || !gpusAvailable}
               onChange={onDriverParamsChange}
               aria-label='text input'
             />
@@ -128,22 +118,39 @@ const ManageGpuModalBody = ({
         </DescriptionListGroup>
         </DescriptionList>
 
-      <TextInput
-        value={searchText}
-        placeholder={msg.vmManageGpuSearchButtonPlaceholder()}
-        type='search'
-        onChange={value => onSearchBoxInput(value)}
-        aria-label='text input'
-        className='vgpu-search-box'
-      />
-      <div className='.vgpu-table-wrapper'>
-        <GpuTable
-          gpus={filteredGpus}
-          selectedMDevTypes={selectedMDevTypes}
-          onGpuSelectionChange={onGpuSelectionChange}
-          className='vgpu-body-element'
-        />
-      </div>
+      {
+        !gpusAvailable && (
+          <Bullseye>
+            <EmptyState variant={EmptyStateVariant.large}>
+              <EmptyStateIcon icon={SearchIcon} />
+              <Title headingLevel='h5' size='lg'>{msg.vmManageGpuEmptyStateTitle()}</Title>
+              <EmptyStateBody>{msg.vmManageGpuEmptyStateBody()}</EmptyStateBody>
+            </EmptyState>
+          </Bullseye>
+        )
+      }
+      {
+        gpusAvailable && (
+          <div>
+            <TextInput
+              value={searchText}
+              placeholder={msg.vmManageGpuSearchButtonPlaceholder()}
+              type='search'
+              onChange={value => onSearchBoxInput(value)}
+              aria-label='text input'
+              className='vgpu-search-box'
+            />
+            <div className='.vgpu-table-wrapper'>
+              <GpuTable
+                gpus={filteredGpus}
+                selectedMDevTypes={selectedMDevTypes}
+                onGpuSelectionChange={onGpuSelectionChange}
+                className='vgpu-body-element'
+              />
+            </div>
+          </div>
+        )
+      }
     </div>
   )
 }


### PR DESCRIPTION
Currently, if a VM is set with vGPU but its cluster does not contain vGPU hosts any more, it is not possible to view
the configuration or to remove the devices and as a result to run the VM.
![image](https://user-images.githubusercontent.com/2078072/161770313-ef16b22f-4912-475e-b5d2-162c665b17e9.png)
This patch allows to review the configuration and to remove the devices in case there are no vGPU hosts in the cluster.
![image](https://user-images.githubusercontent.com/2078072/161770384-3ef8ae89-4f09-44e1-b7e3-ce7c14c255a7.png)
