### PR TITLE
Add support for Georgian language as a community translation

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -12,6 +12,7 @@ export const supportedLocales = [
   'fr-FR',
   'it-IT',
   'ja-JP',
+  'ka-GE',
   'ko-KR',
   'pt-BR',
   'zh-CN',

--- a/src/services/app-init.js
+++ b/src/services/app-init.js
@@ -15,6 +15,7 @@ const polyfillIntlFn = (resolve, reject) => {
       require('intl/locale-data/jsonp/fr')
       require('intl/locale-data/jsonp/it')
       require('intl/locale-data/jsonp/ja')
+      require('intl/locale-data/jsonp/ka')
       require('intl/locale-data/jsonp/ko')
       require('intl/locale-data/jsonp/pt')
       require('intl/locale-data/jsonp/zh')

--- a/zanata/zanata-pull.sh
+++ b/zanata/zanata-pull.sh
@@ -1,7 +1,7 @@
 #! /usr/bin/env bash
 [[ -e zanata.xml ]] || cd zanata
 
-ZANATA_LOCALES=de,es,fr,it,ja,ko,pt-BR,zh-CN,cs
+ZANATA_LOCALES=de,es,fr,it,ja,ko,pt-BR,zh-CN,cs,ka
 
 mvn \
     at.porscheinformatik.zanata:zanata-maven-plugin:4.7.8:pull \

--- a/zanata/zanata-push.sh
+++ b/zanata/zanata-push.sh
@@ -1,7 +1,7 @@
 #! /usr/bin/env bash
 [[ -e zanata.xml ]] || cd zanata
 
-ZANATA_LOCALES=de,es,fr,it,ja,ko,pt-BR,zh-CN,cs
+ZANATA_LOCALES=de,es,fr,it,ja,ko,pt-BR,zh-CN,cs,ka
 
 mvn \
     at.porscheinformatik.zanata:zanata-maven-plugin:4.7.8:push \


### PR DESCRIPTION
Enable use of community provided translation for Georgian.  After this PR is merged, another PR to import the translation itself should be done.

Related changes:
  - ovirt-web-ui: https://github.com/oVirt/ovirt-web-ui/pull/1582
  - ovirt-engine: https://github.com/oVirt/ovirt-engine/pull/269

Zanata link: https://zanata.ovirt.org/iteration/view/ovirt-engine-ui-extensions/1.3/languages/ka
