### PR TITLE
Cpu Pinning: fix trailing zero in case of no CPU topology was found

### DIFF
--- a/src/modals/cpu-pinning/CpuPinningModalBody.js
+++ b/src/modals/cpu-pinning/CpuPinningModalBody.js
@@ -153,7 +153,7 @@ const CpuPinningModalBody = ({
             !mainEntity.cpuPinningTopology.numberOfSockets() && msg.cpuPinningModalEmptyState()
           }
           {
-            mainEntity.cpuPinningTopology.numberOfSockets() && (
+            mainEntity.cpuPinningTopology.numberOfSockets() > 0 && (
               <div className='cpu-pinning-body'>
                 <div className='cpu-pinning-body-description'>{cpuTopologyDescription}</div>
                 <CpuTopology


### PR DESCRIPTION
When fetching cpu units for a specific host (`cpuunits` endpoint ) returns an empty reply, the following message appears with a trailing zero "`No CPU topology found0`":
![image](https://user-images.githubusercontent.com/18169498/164273071-c58b0f7d-c75f-4814-b4fd-a9ba6d13dc09.png)
This PR fixes it by replacing the zero value (converted to str) with a boolean value.
After this fix:
![image](https://user-images.githubusercontent.com/18169498/164273712-c439b7ed-5722-4e23-92a7-8c73e1ecf459.png)
