### PR TITLE
mark the copr make_srpm git dir as safe (git 2.35.2 security fix)

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -4,6 +4,11 @@
 installdeps:
 	dnf -y install git jq rpmlint rpm-build
 
-srpm: installdeps
+# explicity mark the copr generated git repo directory (which is done prior to the mock
+# call to the make_srpm and will be the current pwd) as safe for git commands
+git-safe:
+	git config --global --add safe.directory "$(shell pwd)"
+
+srpm: installdeps git-safe
 	./packaging/build.sh copr
 	cp exported-artifacts/*.src.rpm $(outdir)


### PR DESCRIPTION
See [CVE-2022-24765](https://github.blog/2022-04-12-git-security-vulnerability-announced/)

git >= 2.35.2 won't work on copr `make_srpm` builds without marking
the working directory as a `safe.directory` in git.

With copr using the `make_srpm` build SRPM type, the source build will
first create a git repo as per the package source configurations.  Then
it uses mock to runs the `.copr/Makefile srpm` target with the working
directory set to the root of the initial git clone.  Since the user
that created the git repo is different from the user running in the
mock container, the CVE mitigation is hit and `git` will fail to run.

This change explicitly adds the working directory as a `safe.directory`
allowing git commands used during the `srpm` build to function.