### PR TITLE
build: add conditional build for offline/online builds

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -137,9 +137,6 @@ Whenever `dependencies` are changed, they need to be pre-seeded to
 https://github.com/oVirt/ovirt-engine-nodejs-modules[ovirt-engine-nodejs-modules]
 for CI to pass offline builds.
 
-See the https://github.com/oVirt/ovirt-engine-nodejs-modules/blob/master/pre-seed/README.adoc[pre-seed documentation]
-for deatils on that process.
-
 === Package versioning
 
 * alpha and beta builds (pre-releases): `x.y.z-0.N` where version stays the same

--- a/packaging/build.sh
+++ b/packaging/build.sh
@@ -40,7 +40,6 @@ sed \
   -e "s|@RPM_VERSION@|${version}|g" \
   -e "s|@RPM_SNAPSHOT@|${snapshot}|g" \
   -e "s|@TAR_FILE@|${tar_file}|g" \
-  -e "s|@OFFLINE_BUILD@|${OFFLINE_BUILD:-1}|g" \
   < "${spec_template}" \
   > "${spec_file}"
 
@@ -63,6 +62,7 @@ else
   rpmbuild \
     -ba \
     --define="_topdir ${top_dir}" \
+    $([[ ${OFFLINE_BUILD:-1} -eq 0 ]] && echo "--without ovirt_use_nodejs_modules" || :) \
     "${spec_file}"
 fi
 

--- a/packaging/spec.in
+++ b/packaging/spec.in
@@ -1,4 +1,8 @@
-%define offline_build @OFFLINE_BUILD@
+# build condition `ovirt_use_nodejs_modules`
+#   - on by default, requires a build with `--without ovirt_use_nodejs_modules` to turn off
+#   - if on, the build uses `ovirt-engine-nodejs-modules`
+#   - if off, the build uses standard `yarn` accessing all node_modules packages directly
+%bcond_without ovirt_use_nodejs_modules
 
 Name: ovirt-engine-ui-extensions
 Summary: oVirt UI Extensions
@@ -16,7 +20,7 @@ BuildRequires: jq
 BuildRequires: rpmlint
 BuildRequires: rpm-build
 
-%if %{offline_build}
+%if %{with ovirt_use_nodejs_modules}
 # nodejs-modules embeds yarn and requires nodejs
 BuildRequires: ovirt-engine-nodejs-modules >= 2.2.3-1
 %else
@@ -53,7 +57,7 @@ Extensions include:
 %build
 
 # Set up Node.js environment with dependencies linked to ./node_modules:
-%if %{offline_build}
+%if %{with ovirt_use_nodejs_modules}
 source %{_datadir}/ovirt-engine-nodejs-modules/setup-env.sh
 %else
 yarn install


### PR DESCRIPTION
Instead of sed swapping in a 0 or 1 for a `%define` variable
in the `spec.in` file for `OFFLINE_BUILD`, add a conditional build.
See [1] for how they work.

With a conditional build, source rpms retain the ability to build with
different options depending on how `rpmbuild` is called.  This allows
an offline (using `ovirt-engine-nodejs-modules`) or online (using
`yarn install`) build from srpm to be selected at build time using
`--with` or `--without` build options.

Since at least copr builds chroots directly from a srpm, conditional
builds can be used to change build options.  With this change, an
"online build" can be enabled simply by configuring the target chroot
setting "without" to include "ovirt_use_nodejs_modules".

Notes:
  - An offline build with `ovirt-engine-nodejs-modules` is the default

  - An online build using standard `yarn install` can be achieved by
    using `--without ovirt_use_nodejs_modules` on the call to rpmbuild

  - Setting env var `OFFLINE_BUILD=0` when calling `make rpm` will
    add the `--without` option, and run an offline build.  This is
    the same behavior as previous.

[1] - https://rpm-software-management.github.io/rpm/manual/conditionalbuilds.html

**Note**: PR https://github.com/oVirt/ovirt-web-ui/pull/1616 adds the same functionality to ovirt-engine-ui-extensions with the same option name.  With both in place, online and offline builds can be configured for both packages with the same single option on a copr chroot config.