### PR TITLE
cluster upgrade: fix `trackUpgradeProgress` to always fetch events from the last point

### DIFF
--- a/src/modals/cluster-upgrade/data.js
+++ b/src/modals/cluster-upgrade/data.js
@@ -262,7 +262,7 @@ export async function trackUpgradeProgress (correlationId, tick) {
   const track = async () => {
     // figure out data for the tick from the current set of events
     const nextEvents = await fetchNextEvents(correlationId, lastEventId)
-    lastEventId = nextEvents.length === 0 ? -1 : nextEvents[nextEvents.length - 1].id
+    lastEventId = nextEvents.length === 0 ? lastEventId : nextEvents[nextEvents.length - 1].id
 
     const eventsForLog = nextEvents.map(formatEventAsLogEntry)
     const maxPercentInEvents = nextEvents.reduce((maxPercent, event) => {


### PR DESCRIPTION
If the upgrade process took more than the `TRACK_FREQUENCY_MS` fetch
interval to generate events, the code would jump back to the beginning
of the events and fetch too many for display.  Make sure not to reset
the `lastEventId` improperly.