### PR TITLE
cluster upgrade: refactor progress tracking

### DIFF
--- a/src/modals/cluster-upgrade/ClusterUpgradeDataProvider.js
+++ b/src/modals/cluster-upgrade/ClusterUpgradeDataProvider.js
@@ -44,7 +44,7 @@ const ClusterUpgradeDataProvider = ({ children, cluster }) => {
       return
     }
 
-    trackUpgradeProgress(cluster.id, correlationId, ({ isRunning, percent, log }) => {
+    trackUpgradeProgress(correlationId, ({ isRunning, percent, log }) => {
       setUpgradeStatus(isRunning ? ProgressStatus.STARTED : ProgressStatus.COMPLETE)
       setUpgradePercent(percent)
       setUpgradeLog(currentLog => [...currentLog, ...log])
@@ -52,7 +52,7 @@ const ClusterUpgradeDataProvider = ({ children, cluster }) => {
     return () => {
       cancelTracker(correlationId)
     }
-  }, [cluster.id, correlationId])
+  }, [correlationId])
 
   const upgradeAndTrack = (upgradePayload) => {
     const cid = randomHexString(10)

--- a/src/modals/cluster-upgrade/ClusterUpgradeDataProvider.js
+++ b/src/modals/cluster-upgrade/ClusterUpgradeDataProvider.js
@@ -14,6 +14,7 @@ import {
   jumpToEvents,
   trackUpgradeProgress,
   cancelTracker,
+  ProgressStatus,
 } from './data'
 
 /**
@@ -33,7 +34,7 @@ const ClusterUpgradeDataProvider = ({ children, cluster }) => {
   })
 
   const [correlationId, setCorrelationId] = useState()
-  const [upgradeStatus, setUpgradeStatus] = useState('pending')
+  const [upgradeStatus, setUpgradeStatus] = useState(ProgressStatus.PENDING)
   const [upgradePercent, setUpgradePercent] = useState(0)
   const [upgradeLog, setUpgradeLog] = useState([])
 
@@ -44,7 +45,7 @@ const ClusterUpgradeDataProvider = ({ children, cluster }) => {
     }
 
     trackUpgradeProgress(cluster.id, correlationId, ({ isRunning, percent, log }) => {
-      setUpgradeStatus(isRunning ? 'started' : 'complete')
+      setUpgradeStatus(isRunning ? ProgressStatus.STARTED : ProgressStatus.COMPLETE)
       setUpgradePercent(percent)
       setUpgradeLog(currentLog => [...currentLog, ...log])
     })

--- a/src/modals/cluster-upgrade/ClusterUpgradeModal.js
+++ b/src/modals/cluster-upgrade/ClusterUpgradeModal.js
@@ -27,7 +27,9 @@ const ClusterUpgradeModal = ({
   isLoading = false,
   cluster,
   clusterHosts,
-  correlationId,
+  upgradeStatus,
+  upgradePercent,
+  upgradeLog,
   upgradeCluster = () => {}, // only needed for the wizard
   jumpToEvents = () => {}, // only needed for the wizard
   onClose,
@@ -135,7 +137,10 @@ const ClusterUpgradeModal = ({
       <ClusterUpgradeWizard
         cluster={cluster}
         clusterHosts={clusterHosts}
-        correlationId={correlationId}
+        upgradeStatus={upgradeStatus}
+        upgradePercent={upgradePercent}
+        upgradeLog={upgradeLog}
+
         upgradeCluster={upgradeCluster}
         onClose={close}
         onJumpToEvents={onJumpToEvents}
@@ -149,7 +154,9 @@ ClusterUpgradeModal.propTypes = {
   isLoading: PropTypes.bool,
   cluster: PropTypes.object,
   clusterHosts: PropTypes.arrayOf(PropTypes.object),
-  correlationId: PropTypes.string,
+  upgradeStatus: PropTypes.string,
+  upgradePercent: PropTypes.number,
+  upgradeLog: PropTypes.arrayOf(PropTypes.object),
 
   // callbacks
   upgradeCluster: PropTypes.func,

--- a/src/modals/cluster-upgrade/ClusterUpgradeModal.js
+++ b/src/modals/cluster-upgrade/ClusterUpgradeModal.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import { msg } from '_/intl-messages'
+import { ProgressStatus } from './data'
 
 import {
   Button,
@@ -154,7 +155,7 @@ ClusterUpgradeModal.propTypes = {
   isLoading: PropTypes.bool,
   cluster: PropTypes.object,
   clusterHosts: PropTypes.arrayOf(PropTypes.object),
-  upgradeStatus: PropTypes.string,
+  upgradeStatus: PropTypes.oneOf(Object.values(ProgressStatus)),
   upgradePercent: PropTypes.number,
   upgradeLog: PropTypes.arrayOf(PropTypes.object),
 

--- a/src/modals/cluster-upgrade/ClusterUpgradeWizard.js
+++ b/src/modals/cluster-upgrade/ClusterUpgradeWizard.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import { msg } from '_/intl-messages'
+import { ProgressStatus } from './data'
 
 import { Wizard } from '@patternfly/react-core'
 import SelectHosts from './SelectHosts'
@@ -178,7 +179,7 @@ ClusterUpgradeWizard.propTypes = {
   // data input
   cluster: PropTypes.object,
   clusterHosts: PropTypes.arrayOf(PropTypes.object),
-  upgradeStatus: PropTypes.string,
+  upgradeStatus: PropTypes.oneOf(Object.values(ProgressStatus)),
   upgradePercent: PropTypes.number,
   upgradeLog: PropTypes.arrayOf(PropTypes.object),
 

--- a/src/modals/cluster-upgrade/ClusterUpgradeWizard.js
+++ b/src/modals/cluster-upgrade/ClusterUpgradeWizard.js
@@ -19,7 +19,10 @@ import TrackProgress from './TrackProgress'
 const ClusterUpgradeWizard = ({
   cluster,
   clusterHosts,
-  correlationId,
+  upgradeStatus,
+  upgradePercent,
+  upgradeLog,
+
   upgradeCluster,
   onJumpToEvents,
   onClose,
@@ -136,7 +139,9 @@ const ClusterUpgradeWizard = ({
       component: (
         <TrackProgress
           cluster={cluster}
-          correlationId={correlationId}
+          upgradeStatus={upgradeStatus}
+          upgradePercent={upgradePercent}
+          upgradeLog={upgradeLog}
           onClose={onClose}
           onJumpToEvents={onJumpToEvents}
         />
@@ -173,7 +178,9 @@ ClusterUpgradeWizard.propTypes = {
   // data input
   cluster: PropTypes.object,
   clusterHosts: PropTypes.arrayOf(PropTypes.object),
-  correlationId: PropTypes.string,
+  upgradeStatus: PropTypes.string,
+  upgradePercent: PropTypes.number,
+  upgradeLog: PropTypes.arrayOf(PropTypes.object),
 
   // operation callback
   upgradeCluster: PropTypes.func.isRequired,

--- a/src/modals/cluster-upgrade/TrackProgress.js
+++ b/src/modals/cluster-upgrade/TrackProgress.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import IntlMessageFormat from 'intl-messageformat'
 import { msg } from '_/intl-messages'
 import { currentLocale } from '_/utils/intl'
+import { ProgressStatus } from './data'
 
 import {
   Alert,
@@ -20,22 +21,22 @@ import {
 import { CogsIcon } from '@patternfly/react-icons'
 
 const STATUS_TO_TITLE = {
-  'pending': (clusterName) => msg.clusterUpgradeOperationPending({ clusterName }),
-  'started': (clusterName) => msg.clusterUpgradeOperationStarted({ clusterName }),
-  'complete': (clusterName) => msg.clusterUpgradeOperationComplete({ clusterName }),
-  'failed': (clusterName) => msg.clusterUpgradeOperationFailed({ clusterName }),
+  [ProgressStatus.PENDING]: (clusterName) => msg.clusterUpgradeOperationPending({ clusterName }),
+  [ProgressStatus.STARTED]: (clusterName) => msg.clusterUpgradeOperationStarted({ clusterName }),
+  [ProgressStatus.COMPLETE]: (clusterName) => msg.clusterUpgradeOperationComplete({ clusterName }),
+  [ProgressStatus.FAILED]: (clusterName) => msg.clusterUpgradeOperationFailed({ clusterName }),
 }
 
 const STATUS_TO_PROGRESS_VARIANT = {
-  'pending': null,
-  'started': null,
-  'complete': 'success',
-  'failed': 'warning',
+  [ProgressStatus.PENDING]: null,
+  [ProgressStatus.STARTED]: null,
+  [ProgressStatus.COMPLETE]: 'success',
+  [ProgressStatus.FAILED]: 'warning',
 }
 
 const TrackProgress = ({
   cluster,
-  upgradeStatus = 'pending',
+  upgradeStatus = ProgressStatus.PENDING,
   upgradePercent = 0,
   upgradeLog = [],
   onJumpToEvents,
@@ -81,7 +82,7 @@ const TrackProgress = ({
 }
 TrackProgress.propTypes = {
   cluster: PropTypes.object.isRequired,
-  upgradeStatus: PropTypes.string,
+  upgradeStatus: PropTypes.oneOf(Object.values(ProgressStatus)),
   upgradePercent: PropTypes.number,
   upgradeLog: PropTypes.arrayOf(PropTypes.shape({
     id: PropTypes.number,

--- a/src/modals/cluster-upgrade/data.js
+++ b/src/modals/cluster-upgrade/data.js
@@ -254,7 +254,7 @@ function formatEventAsLogEntry ({ id, description, time }) {
   return { id, description, time }
 }
 
-export async function trackUpgradeProgress (correlationId, tick) {
+export async function trackUpgradeProgress (clusterId, correlationId, tick) {
   const progressRegEx = /^Cluster upgrade progress: (\d+)%(, Cluster: (.*?))?(, Host: (.*?))? \[(.*)\]$/
   let lastEventId = -1
   let lastPercent = 0

--- a/src/modals/cluster-upgrade/data.js
+++ b/src/modals/cluster-upgrade/data.js
@@ -181,6 +181,13 @@ export function jumpToEvents (correlationId) {
 //
 // Functions to handle progress tracking by looking at the event log
 //
+export const ProgressStatus = {
+  PENDING: 'pending',
+  STARTED: 'started',
+  COMPLETE: 'complete',
+  FAILED: 'failed',
+}
+
 const trackerByCorrelation = {}
 
 function scheduleTrackTick (timeout, correlationId, track) {

--- a/src/modals/cluster-upgrade/data.js
+++ b/src/modals/cluster-upgrade/data.js
@@ -261,7 +261,7 @@ function formatEventAsLogEntry ({ id, description, time }) {
   return { id, description, time }
 }
 
-export async function trackUpgradeProgress (clusterId, correlationId, tick) {
+export async function trackUpgradeProgress (correlationId, tick) {
   const progressRegEx = /^Cluster upgrade progress: (\d+)%(, Cluster: (.*?))?(, Host: (.*?))? \[(.*)\]$/
   let lastEventId = -1
   let lastPercent = 0


### PR DESCRIPTION
Refactor progress tracking, moving it from `TrackProgress` to `ClusterUpgradeDataProvider`.

This way `ClusterUpgradeDataProvider` is the thing in charge of all data access for the modal.

Note: Before #50, modals would be unmounted and recreated with each prop update done in a data provider. After PR #50, prop updates work as expected, and changes are pushed down.  :smile: 