### PR TITLE
build: Use hours, minutes and seconds in RPM version

### DIFF
--- a/packaging/build.sh
+++ b/packaging/build.sh
@@ -8,7 +8,7 @@ test -d exported-artifacts && rm -rf exported-artifacts || :
 
 # Resolve the version and snapshot used for RPM build:
 version="$(jq -r '.version' package.json)"
-date="$(date --utc +%Y%m%d)"
+date="$(date --utc +%Y%m%d%H%M%S)"
 commit="$(git log -1 --pretty=format:%h)"
 snapshot=".${date}git${commit}"
 


### PR DESCRIPTION
Using only the date part in RPM snapshots names is not fine enough - when a couple
of builds land in COPR with the same date, the one with the "biggest SHA"
wins, even though it might not actually be the latest build.