### PR TITLE
Fix UtilizationBarChart percentage message parameter value

### DIFF
--- a/src/components/patternfly/UtilizationBarChart.js
+++ b/src/components/patternfly/UtilizationBarChart.js
@@ -46,7 +46,7 @@ const UtilizationBarChart = ({
       )}
       { footerLabel === 'percent' && (
         <div className='bar-chart-label' style={{ maxWidth: footerLabelWidth }}>
-          <strong>{formatPercent0D(percentUsed)}</strong> {msg.used()}
+          <strong>{formatPercent0D(percentUsed / 100)}</strong> {msg.used()}
         </div>
       )}
       { typeof footerLabel === 'function' && (


### PR DESCRIPTION
The Intl.NumberFormat usage for percent value style requires a fraction and not a
percent value.
Check https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#decimal_and_percent_formatting

Since the UtilizationBarChart values are calculated in percent already
https://github.com/oVirt/ovirt-engine-ui-extensions/blob/6b2d486846b4835f7737b68fe8dfb224e538ce5e/src/components/patternfly/UtilizationBarChart.js#L18
then need to divide them by 100 to convert to a fraction again.

I went over all other formatPercent method usages to check that we
didn't miss other such occurences and it looks ok.

Bug-Url: https://bugzilla.redhat.com/2108612