### PR TITLE
Null value blockes user export to daa domain

### DIFF
--- a/src/modals/vm-export/VmExportDataProvider.js
+++ b/src/modals/vm-export/VmExportDataProvider.js
@@ -40,7 +40,7 @@ async function validateThinVm (vmId, sdId) {
   const vm = await engineGet(`api/vms/${vmId}`)
 
   // If a VM has both attributes set it's thin/dependent
-  if (vm.original_template.id === emptyGuid || vm.template.id === emptyGuid) {
+  if (vm.original_template?.id === emptyGuid || vm.template.id === emptyGuid) {
     return true
   }
 


### PR DESCRIPTION
If a user somehow has null as original_tamplate in a vm values then export to data domain will be blocked by an error. the bug fix will the blocker.

Bug-Url: https://bugzilla.redhat.com/2100194
Signed-off-by: Artiom Divak <adivak@redhat.com>